### PR TITLE
fix: split long content into chunks when sending to panes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "editprompt",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "A CLI tool that lets you write prompts for CLI tools using your favorite text editor",
   "keywords": [
     "cli",

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,3 +1,16 @@
 export const TEMP_FILE_PREFIX = ".editprompt-";
 export const TEMP_FILE_EXTENSION = ".md";
 export const DEFAULT_EDITOR = "vim";
+
+// tmux sends each command to its server as a single imsg frame capped at
+// 16KB (16384 bytes). Use half of that limit as the body chunk size to leave
+// room for the `tmux send-keys -t '...' -- '...'` wrapper and the single-quote
+// escaping expansion. Long content is split into chunks of this size and sent
+// with successive send-keys calls to avoid the "command too long" error.
+const TMUX_IMSG_LIMIT_BYTES = 16 * 1024;
+export const TMUX_SEND_CHUNK_BYTES = TMUX_IMSG_LIMIT_BYTES / 2;
+
+// wezterm's send-text passes content as a shell argument, which is bounded by
+// ARG_MAX (typically 256KB+) rather than imsg, so it has more headroom. Reuse
+// the same chunk size for simplicity and consistency.
+export const WEZTERM_SEND_CHUNK_BYTES = TMUX_SEND_CHUNK_BYTES;

--- a/src/modules/tmux.ts
+++ b/src/modules/tmux.ts
@@ -1,6 +1,8 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
 import { getLogger } from "@logtape/logtape";
+import { TMUX_SEND_CHUNK_BYTES } from "../config/constants";
+import { splitByByteSize } from "../utils/contentChunker";
 
 const execAsync = promisify(exec);
 const logger = getLogger(["editprompt", "tmux"]);
@@ -127,7 +129,15 @@ export async function inputToTmuxPane(paneId: string, content: string): Promise<
     `tmux if-shell -t '${paneId}' '[ "#{pane_in_mode}" = "1" ]' "copy-mode -q -t '${paneId}'"`,
   );
 
-  // Send content using send-keys command (no focus change)
-  await execAsync(`tmux send-keys -t '${paneId}' -- '${content.replace(/'/g, "'\\''")}'`);
-  logger.debug("Content sent to tmux pane: {paneId}", { paneId });
+  // Split long content into chunks to stay under tmux's imsg frame limit,
+  // then send each chunk in order (no focus change). The --auto-send Enter is
+  // sent separately by the caller after all chunks, so it fires only once.
+  const chunks = splitByByteSize(content, TMUX_SEND_CHUNK_BYTES);
+  for (const chunk of chunks) {
+    await execAsync(`tmux send-keys -t '${paneId}' -- '${chunk.replace(/'/g, "'\\''")}'`);
+  }
+  logger.debug("Content sent to tmux pane: {paneId} ({chunks} chunk(s))", {
+    paneId,
+    chunks: chunks.length,
+  });
 }

--- a/src/modules/wezterm.ts
+++ b/src/modules/wezterm.ts
@@ -1,6 +1,8 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
 import { getLogger } from "@logtape/logtape";
+import { WEZTERM_SEND_CHUNK_BYTES } from "../config/constants";
+import { splitByByteSize } from "../utils/contentChunker";
 import { conf } from "./conf";
 
 const logger = getLogger(["editprompt", "wezterm"]);
@@ -190,9 +192,17 @@ export async function sendKeyToWeztermPane(
 }
 
 export async function inputToWeztermPane(paneId: string, content: string): Promise<void> {
-  // Send content using wezterm cli send-text command (no focus change)
-  await execAsync(
-    `wezterm cli send-text --no-paste --pane-id '${paneId}' -- '${content.replace(/'/g, "'\\''")}'`,
-  );
-  logger.debug("Content sent to wezterm pane: {paneId}", { paneId });
+  // Split long content into chunks and send each in order (no focus change),
+  // mirroring the tmux backend. The --auto-send Enter is sent separately by the
+  // caller after all chunks, so it fires only once.
+  const chunks = splitByByteSize(content, WEZTERM_SEND_CHUNK_BYTES);
+  for (const chunk of chunks) {
+    await execAsync(
+      `wezterm cli send-text --no-paste --pane-id '${paneId}' -- '${chunk.replace(/'/g, "'\\''")}'`,
+    );
+  }
+  logger.debug("Content sent to wezterm pane: {paneId} ({chunks} chunk(s))", {
+    paneId,
+    chunks: chunks.length,
+  });
 }

--- a/src/utils/contentChunker.ts
+++ b/src/utils/contentChunker.ts
@@ -1,0 +1,34 @@
+/**
+ * Split content into chunks not exceeding maxBytes (UTF-8 byte count),
+ * never breaking a Unicode code point across chunks.
+ *
+ * Content shorter than maxBytes is returned as a single chunk, so short
+ * input keeps the previous behavior of being sent in one shot.
+ */
+export function splitByByteSize(content: string, maxBytes: number): string[] {
+  if (content === "") {
+    return [];
+  }
+
+  const chunks: string[] = [];
+  let current = "";
+  let currentBytes = 0;
+
+  // Iterate by code point so multi-byte characters are never split.
+  for (const char of content) {
+    const charBytes = Buffer.byteLength(char, "utf8");
+    if (current !== "" && currentBytes + charBytes > maxBytes) {
+      chunks.push(current);
+      current = "";
+      currentBytes = 0;
+    }
+    current += char;
+    currentBytes += charBytes;
+  }
+
+  if (current !== "") {
+    chunks.push(current);
+  }
+
+  return chunks;
+}

--- a/test/utils/contentChunker.test.ts
+++ b/test/utils/contentChunker.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { splitByByteSize } from "../../src/utils/contentChunker";
+
+describe("splitByByteSize", () => {
+  test("returns empty array for empty string", () => {
+    expect(splitByByteSize("", 8)).toEqual([]);
+  });
+
+  test("returns single chunk when content fits within maxBytes", () => {
+    const input = "hello";
+    expect(splitByByteSize(input, 8)).toEqual(["hello"]);
+  });
+
+  test("returns single chunk when content length equals maxBytes", () => {
+    const input = "abcd";
+    expect(splitByByteSize(input, 4)).toEqual(["abcd"]);
+  });
+
+  test("splits ASCII content into the expected number of chunks", () => {
+    const input = "abcdefghij"; // 10 bytes
+    const chunks = splitByByteSize(input, 4);
+    expect(chunks).toEqual(["abcd", "efgh", "ij"]);
+    expect(chunks.join("")).toBe(input);
+  });
+
+  test("never splits a multi-byte character across chunks", () => {
+    const input = "あいう"; // each char is 3 UTF-8 bytes -> 9 bytes total
+    const chunks = splitByByteSize(input, 4);
+    // Only one 3-byte char fits per 4-byte chunk.
+    expect(chunks).toEqual(["あ", "い", "う"]);
+    for (const chunk of chunks) {
+      expect(Buffer.byteLength(chunk, "utf8")).toBeLessThanOrEqual(4);
+    }
+    expect(chunks.join("")).toBe(input);
+  });
+
+  test("handles surrogate-pair emoji without breaking code points", () => {
+    const input = "😀😀😀"; // each emoji is 4 UTF-8 bytes
+    const chunks = splitByByteSize(input, 4);
+    expect(chunks).toEqual(["😀", "😀", "😀"]);
+    for (const chunk of chunks) {
+      expect(Buffer.byteLength(chunk, "utf8")).toBeLessThanOrEqual(4);
+    }
+    expect(chunks.join("")).toBe(input);
+  });
+
+  test("preserves content exactly for long mixed input", () => {
+    const input = `${"a".repeat(5000)}あ${"b".repeat(5000)}😀${"c".repeat(5000)}`;
+    const maxBytes = 1024;
+    const chunks = splitByByteSize(input, maxBytes);
+    for (const chunk of chunks) {
+      expect(Buffer.byteLength(chunk, "utf8")).toBeLessThanOrEqual(maxBytes);
+    }
+    expect(chunks.join("")).toBe(input);
+  });
+
+  test("emits a single chunk wider than maxBytes only when one char exceeds it", () => {
+    // A single 4-byte char cannot fit in a 2-byte limit, but it must not be
+    // dropped or split; it is emitted as its own chunk.
+    const chunks = splitByByteSize("😀", 2);
+    expect(chunks).toEqual(["😀"]);
+  });
+});


### PR DESCRIPTION
## Summary

Neovim の editprompt.nvim から ~24KB の prompt を Claude Code pane へ送ると `editprompt input --auto-send` が `All target panes failed to receive content` で失敗していた（stderr に tmux の `command too long`）。

原因は本文全体を**1回の `send-keys`** に載せていたこと。tmux はコマンドをサーバへ単一の imsg フレームで渡すが、その上限が 16KB (16384 bytes) のため、16KB を超える本文で失敗していた（報告の「15KB台は通り、16KB台で失敗」と一致）。

## Changes

- `src/utils/contentChunker.ts` (新規): `splitByByteSize(content, maxBytes)` — UTF-8 コードポイント境界で分割する純粋関数。マルチバイト文字や絵文字（サロゲートペア）を途中で壊さない
- `src/config/constants.ts`: チャンクサイズを tmux の imsg 制限から導出（`TMUX_IMSG_LIMIT_BYTES / 2` = 8192）。wezterm 用も同値で定義
- `src/modules/tmux.ts` / `src/modules/wezterm.ts`: 本文送信を分割化し、各 chunk を順次送信
- `--auto-send` の Enter は本文送信**後**に別関数で送られる構造のため、最後の chunk 後に1回だけ送られる（要件を自動的に満たす）
- 短い本文（8KB以下）は1 chunk なので従来と完全に同じ挙動
- v1.5.0 リリース

## Test

- `test/utils/contentChunker.test.ts` (新規): 分割個数、マルチバイト・絵文字の非破壊、`join()` での完全復元、短文1chunk、空文字列を検証
- `bun test` → 全 pass / `bun run build` → 成功 / `bunx biome check` → クリーン
- 実機で 24KB の本文送信が成功することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)