### PR TITLE
Add Herdr multiplexer support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is `editprompt`, a CLI tool that lets you write prompts for CLI tools using your favorite text editor. Originally designed for Claude Code, but now works with any CLI process. It detects running target processes and sends content to them via tmux integration or clipboard fallback.
+This is `editprompt`, a CLI tool that lets you write prompts for CLI tools using your favorite text editor. Originally designed for Claude Code, but now works with any CLI process. It detects running target processes and sends content to them via tmux, WezTerm, or Herdr integration, or via the clipboard.
 
 ## Development Commands
 
@@ -30,7 +30,7 @@ This is `editprompt`, a CLI tool that lets you write prompts for CLI tools using
 2. **Mode Selection** (`src/modes/`) - Routes to appropriate mode handler (openEditor, resume, sendOnly)
 3. **Editor Module** (`src/modules/editor.ts`) - Handles editor launching and content extraction
 4. **Process Detection** (`src/modules/process.ts`) - Finds target processes (configurable)
-5. **Multiplexer Integration** (`src/modules/tmux.ts`, `src/modules/wezterm.ts`) - Handles multiplexer-specific operations
+5. **Multiplexer Integration** (`src/modules/tmux.ts`, `src/modules/wezterm.ts`, `src/modules/herdr.ts`) - Handles multiplexer-specific operations
 6. **Content Delivery** - Sends to multiplexer panes via `send-keys` or falls back to clipboard
 
 ### Modes
@@ -45,7 +45,7 @@ For detailed mode implementation including constraints and solutions for differe
 
 ### Key Design Patterns
 
-- **Multiplexer-First Strategy**: Supports both tmux and WezTerm with multiplexer-specific implementations
+- **Multiplexer-First Strategy**: Supports tmux, WezTerm, and Herdr with multiplexer-specific implementations
 - **Graceful Fallbacks**: Editor → Process Detection → Multiplexer → Clipboard (with user feedback)
 - **Process Matching**: Links system processes to multiplexer panes for accurate targeting
 - **Mode Separation**: Each mode has isolated logic for different use cases
@@ -53,7 +53,7 @@ For detailed mode implementation including constraints and solutions for differe
 ### Directory Structure
 
 - `modes/`: Mode implementations (openEditor, resume, sendOnly, common)
-- `modules/`: Core functionality modules (editor, process, tmux, wezterm)
+- `modules/`: Core functionality modules (editor, process, tmux, wezterm, herdr)
 - `utils/`: Utility functions (argumentParser, contentProcessor, envParser, sendConfig, tempFile)
 - `config/`: Configuration values (constants)
 - `types/`: TypeScript type definitions
@@ -68,6 +68,7 @@ For detailed mode implementation including constraints and solutions for differe
 - `modules/process.ts`: Process discovery and content delivery mechanisms
 - `modules/tmux.ts`: tmux-specific operations (pane variables, focus switching)
 - `modules/wezterm.ts`: WezTerm-specific operations (Conf-based state management, focus switching)
+- `modules/herdr.ts`: Herdr socket API operations and session-scoped Conf state management
 - `utils/tempFile.ts`: Secure temporary file creation and cleanup
 - `config/constants.ts`: Configuration values (default process name, file patterns, default editor)
 
@@ -75,7 +76,7 @@ For detailed mode implementation including constraints and solutions for differe
 
 - `gunshi` - CLI framework
 - `clipboardy` - Clipboard operations
-- `conf` - Persistent configuration storage (used for WezTerm state management)
+- `conf` - Persistent configuration storage (used for WezTerm and Herdr state management)
 - Native Node.js modules for multiplexer integration and file operations
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A CLI tool that lets you write prompts for CLI tools using your favorite text ed
 ## ✨ Features
 
 - 🖊️ **Editor Integration**: Use your preferred text editor to write prompts
-- 🖥️ **Multiplexer Support**: Send prompts directly to tmux or WezTerm sessions
+- 🖥️ **Multiplexer Support**: Send prompts directly to tmux, WezTerm, or Herdr sessions
 - 🖥️ **Universal Terminal Support**: Works with any terminal via clipboard - no multiplexer required
 - 📤 **Send Without Closing**: Iterate on prompts without closing your editor
 - 📋 **Quote Buffering**: Collect text selections and send them as quoted replies
@@ -88,7 +88,7 @@ Ideal for trial-and-error workflows with AI assistants.
 
 For replying to specific parts of AI responses:
 
-1. Select text in your terminal (tmux copy mode or WezTerm selection) and trigger collect mode
+1. Select text in your terminal and trigger collect mode
 2. Repeat to collect multiple selections
 3. Run `editprompt dump` to retrieve all collected quotes
 4. Edit and send your reply with context
@@ -169,6 +169,24 @@ bind -n M-q run-shell '\
 
 **Note:** The `-lc` flag ensures your shell loads the full login environment, making `editprompt` available in your PATH.
 
+### Herdr Integration
+
+Herdr v0.7.5 or later exposes the pane environment and socket API used by editprompt. Add a custom command to `~/.config/herdr/config.toml`:
+
+```toml
+[[keys.command]]
+key = "prefix+e"
+type = "shell"
+command = 'editprompt toggle --mux herdr --target-pane "$HERDR_ACTIVE_PANE_ID" --editor nvim --always-copy --pane-rows 12'
+description = "open prompt editor"
+```
+
+Run the binding from a target pane. editprompt opens a regular bottom split for the editor; after content is sent, it focuses the target pane again. If an editor pane is already registered, the command focuses that pane instead. Run the same binding from the editor pane to return to the first available target pane without sending content.
+
+`--pane-rows` sets the desired editor height. Herdr limits split ratios to 10–90%, so editprompt uses the requested row count when possible and clamps it to those limits for very short or tall panes. The editor process replaces the split pane's shell, so the pane closes when the editor exits.
+
+Inside a Herdr pane, editprompt automatically selects the Herdr backend when `HERDR_SOCKET_PATH` and a pane ID are available. An explicit `--mux` option or `EDITPROMPT_MUX` value takes precedence, so the binding above keeps `--mux herdr` to make its intent clear.
+
 ### Editor Integration (Send Without Closing)
 
 While editprompt is running, you can send content to the target pane or clipboard without closing the editor. This allows you to iterate quickly on your prompts.
@@ -186,7 +204,8 @@ editprompt input --auto-send -- "your content here"
 
 editprompt input --auto-send --send-key "C-m" -- "your content here"
 # Customize the key to send after content (tmux format example)
-# WezTerm example: --send-key "\r" (default for WezTerm is \r, tmux default is Enter)
+# WezTerm example: --send-key "\r"
+# Herdr example: --send-key "enter"
 ```
 
 This sends the content to the target pane (or clipboard) while keeping your editor open, so you can continue editing and send multiple times.
@@ -197,6 +216,7 @@ This sends the content to the target pane (or clipboard) while keeping your edit
 - `--send-key <key>`: Customize the key to send after content (requires `--auto-send`)
   - tmux format: `Enter` (default), `C-a`, etc.
   - WezTerm format: `\r` (default), `\x01`, etc.
+  - Herdr format: `enter` (default), `ctrl+a`, etc.
 
 #### Neovim Integration
 
@@ -210,11 +230,15 @@ Send individual key inputs to the target pane without leaving your editor. Usefu
 # Send a character key
 editprompt press -- 1
 
-# Send special keys (tmux format)
+# Send special keys (tmux examples)
 editprompt press -- Tab
 editprompt press -- Up
 editprompt press -- C-m    # Enter
 editprompt press -- C-c    # Ctrl+C
+
+# Herdr examples
+editprompt press -- enter
+editprompt press -- ctrl+c
 
 # Send with delay
 editprompt press --delay 500 -- Tab
@@ -228,12 +252,12 @@ editprompt press --delay 500 -- Tab
 
 **Key notation** depends on your multiplexer:
 
-| Key           | tmux          | WezTerm             |
-| ------------- | ------------- | ------------------- |
-| Enter         | `C-m`         | `\r`                |
-| Tab           | `Tab`         | `\t`                |
-| Escape        | `Escape`      | `\x1b`              |
-| Arrow Up/Down | `Up` / `Down` | `\x1b[A` / `\x1b[B` |
+| Key           | tmux          | WezTerm             | Herdr         |
+| ------------- | ------------- | ------------------- | ------------- |
+| Enter         | `C-m`         | `\r`                | `enter`       |
+| Tab           | `Tab`         | `\t`                | `tab`         |
+| Escape        | `Escape`      | `\x1b`              | `esc`         |
+| Arrow Up/Down | `Up` / `Down` | `\x1b[A` / `\x1b[B` | `up` / `down` |
 
 ### Quote Workflow Setup
 
@@ -293,6 +317,16 @@ return {
 3. Repeat to collect multiple quotes
 4. All quotes are stored in a configuration file associated with the target pane
 
+#### Collecting Quotes in Herdr
+
+Pass selected text as an argument together with the target pane ID:
+
+```bash
+editprompt collect --mux herdr --target-pane "$HERDR_PANE_ID" -- "selected text"
+```
+
+This can be called from a script or editor integration that has access to the selected text. Herdr quote buffers are stored in editprompt's configuration, associated with the target pane.
+
 #### Capturing Collected Quotes
 
 Run this command from within your editor pane to retrieve all collected quotes:
@@ -315,6 +349,7 @@ This copies all collected quotes to the clipboard and clears the buffer, ready f
 
 - **tmux**: Quotes are stored in pane variables, automatically cleaned up when the pane closes
 - **WezTerm**: Quotes are stored in a configuration file associated with the pane
+- **Herdr**: Quotes are stored in editprompt's configuration and associated with the pane ID
 - Text is intelligently processed: removes common indentation, handles line breaks smartly
 - Each quote is prefixed with `> ` in markdown quote format
 - Multiple quotes are separated with blank lines

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -96,6 +96,7 @@ editprompt register --editor-pane %10 --target-pane %1 --target-pane %2
 3. **Save relationship**:
    - **tmux**: Save as comma-separated values in `@editprompt_target_panes` pane variable
    - **WezTerm**: Save `targetPaneIds` as an array using Conf library
+   - **Herdr**: Save `targetPaneIds` as an array using Conf library
 
 ---
 
@@ -155,6 +156,20 @@ When switching back from the editor pane, it focuses on the first existing targe
 
 This approach enables bidirectional focus switching in WezTerm, similar to tmux.
 
+#### Herdr Implementation
+
+- **Pane discovery**: Uses `HERDR_PANE_ID` inside panes and `HERDR_ACTIVE_PANE_ID` in detached custom commands
+- **Pane control**: Uses Herdr's newline-delimited JSON socket API through `HERDR_SOCKET_PATH`
+- **Editor launch**: `toggle` focuses an existing editor or creates a regular bottom split sized with `--pane-rows`
+  - Herdr split ratios are clamped to 10–90%, so the requested row count is approximated outside that range
+  - The split shell is replaced with `editprompt open`, so the pane closes when the editor exits
+- **State storage**: Uses Conf because Herdr pane metadata is not an editprompt-owned key/value store
+  - State is namespaced by a hash of `HERDR_SOCKET_PATH` to isolate named sessions
+  - `herdr.session_${hash}.targetPane.pane_${targetPaneId}`: Stores the editor pane ID
+  - `herdr.session_${hash}.editorPane.pane_${editorPaneId}`: Stores target pane IDs
+- **Focus switching**: Uses `pane.get` to validate a pane and `pane.focus` to focus it
+  - Herdr custom commands run detached, so `toggle` uses `HERDR_ACTIVE_PANE_ID` to switch between the editor and its first available target pane
+
 ---
 
 ## input Subcommand
@@ -171,12 +186,13 @@ This mode is designed to be executed from within the editor, reading configurati
 
 1. **When launching the editor in open subcommand**:
    - The following environment variables are set when launching the editor:
-     - `EDITPROMPT_MUX`: Multiplexer to use (`tmux` or `wezterm`)
+     - `EDITPROMPT_MUX`: Multiplexer to use (`tmux`, `wezterm`, or `herdr`)
      - `EDITPROMPT_ALWAYS_COPY`: Clipboard copy configuration
      - `EDITPROMPT=1`: Flag indicating launched by editprompt
    - Target pane IDs are stored in pane variables or Conf:
      - tmux: `@editprompt_target_panes` (comma-separated)
      - wezterm: `targetPaneIds` (array)
+     - herdr: `targetPaneIds` (array)
 
 2. **When executing input subcommand from within the editor**:
    - Execute `editprompt input -- "content"` from editors like Neovim
@@ -215,26 +231,26 @@ This mode shares the same editor pane verification and target pane discovery as 
 
 #### Workflow
 
-1. **Read environment variables**: Gets multiplexer type from `EDITPROMPT_MUX`
+1. **Resolve the multiplexer**: Uses `EDITPROMPT_MUX`, then detects Herdr from `HERDR_SOCKET_PATH` and the pane environment, and otherwise defaults to tmux
 2. **Get current pane ID**: Identifies the editor pane
 3. **Verify editor pane**: Checks that the current pane is registered as an editor pane
-4. **Get target pane IDs**: Retrieves target panes from pane variables (tmux) or Conf (WezTerm)
-5. **Send key**: Sends the specified key to each target pane using `sendKeyToTmuxPane` or `sendKeyToWeztermPane`
+4. **Get target pane IDs**: Retrieves target panes from pane variables (tmux) or Conf (WezTerm/Herdr)
+5. **Send key**: Sends the specified key to each target pane using the selected multiplexer backend
 6. **No focus change**: Focus remains on the editor pane
 
 #### Key Notation
 
 Keys are passed directly to the multiplexer's key-sending mechanism. The notation differs by multiplexer:
 
-| Key        | tmux     | WezTerm  |
-| ---------- | -------- | -------- |
-| Enter      | `C-m`    | `\r`     |
-| Tab        | `Tab`    | `\t`     |
-| Escape     | `Escape` | `\x1b`   |
-| Arrow Up   | `Up`     | `\x1b[A` |
-| Arrow Down | `Down`   | `\x1b[B` |
-| Ctrl+C     | `C-c`    | `\x03`   |
-| Character  | `1`, `a` | `1`, `a` |
+| Key        | tmux     | WezTerm  | Herdr    |
+| ---------- | -------- | -------- | -------- |
+| Enter      | `C-m`    | `\r`     | `enter`  |
+| Tab        | `Tab`    | `\t`     | `tab`    |
+| Escape     | `Escape` | `\x1b`   | `esc`    |
+| Arrow Up   | `Up`     | `\x1b[A` | `up`     |
+| Arrow Down | `Down`   | `\x1b[B` | `down`   |
+| Ctrl+C     | `C-c`    | `\x03`   | `ctrl+c` |
+| Character  | `1`, `a` | `1`, `a` | `1`, `a` |
 
 #### Usage
 
@@ -295,6 +311,11 @@ This mode enables collecting multiple text selections while reading AI responses
 - Example: `editprompt collect --mux wezterm --target-pane <id> -- "<text>"`
 - Uses `wezterm.shell_quote_arg()` for proper escaping
 
+**Herdr Implementation:**
+
+- Receives text as a positional argument
+- Example: `editprompt collect --mux herdr --target-pane <id> -- "<text>"`
+
 #### Text Processing
 
 The `processQuoteText` function applies intelligent text formatting:
@@ -312,7 +333,7 @@ The `processQuoteText` function applies intelligent text formatting:
 
 #### Output Destinations
 
-- Default: `--output buffer` (store in tmux pane variable / WezTerm Conf)
+- Default: `--output buffer` (store in tmux pane variable or WezTerm/Herdr Conf)
 - Tee to stdout: `--output buffer --output stdout` to pipe the same processed text to another command (e.g., clipboard)
 - `--no-quote` applies to all outputs, producing cleaned text without Markdown quote prefix or trailing blank lines
 
@@ -341,6 +362,10 @@ const newQuotes = existingQuotes + "\n" + content;
 conf.set(`wezterm.targetPane.pane_${paneId}.quote_text`, newQuotes);
 ```
 
+**Herdr Implementation:**
+
+- Uses the same Conf-backed representation under the session-scoped `herdr.session_${hash}.targetPane.pane_${paneId}.quote_text`
+
 ### Benefits
 
 - Collect multiple selections from long AI responses or terminal output
@@ -364,10 +389,11 @@ This mode is designed to work with the collect subcommand workflow, retrieving a
 
 Unlike collect subcommand which requires `--target-pane` argument, dump subcommand reads configuration from environment variables and pane variables/Conf:
 
-- `EDITPROMPT_MUX`: Multiplexer type (`tmux` or `wezterm`)
+- `EDITPROMPT_MUX`: Multiplexer type (`tmux`, `wezterm`, or `herdr`)
 - Multiple target pane IDs retrieved from current pane ID:
   - tmux: `@editprompt_target_panes` (comma-separated)
   - wezterm: `targetPaneIds` (array)
+  - herdr: `targetPaneIds` (array)
 
 These configurations are automatically set when launching the editor in open subcommand.
 
@@ -379,9 +405,11 @@ These configurations are automatically set when launching the editor in open sub
 4. **Retrieve quote content**: Fetches accumulated quotes from all target panes
    - **tmux**: Reads from `@editprompt_quote` pane variable
    - **WezTerm**: Reads from `wezterm.targetPane.pane_${paneId}.quote_text` in Conf
+   - **Herdr**: Reads from the session-scoped target pane record in Conf
 5. **Clear storage**: Removes quote content from storage for each target pane after retrieval
    - **tmux**: Sets `@editprompt_quote` to empty string
    - **WezTerm**: Deletes `quote_text` key from Conf
+   - **Herdr**: Deletes `quote_text` key from Conf
 6. **Combine and output**: Joins all quotes with newlines and writes to stdout with trailing newline cleanup (max 2 newlines)
 
 ```typescript
@@ -445,12 +473,16 @@ This command is designed to be executed from within an editor pane launched by e
 
 #### Storage
 
-All stash operations use the Conf library for persistent storage, regardless of multiplexer type (tmux or WezTerm).
+All stash operations use the Conf library for persistent storage, regardless of multiplexer type (tmux, WezTerm, or Herdr).
 
 **Storage Key Structure:**
 
 ```typescript
+// tmux and WezTerm
 `${mux}.targetPane.pane_${targetPaneId}.stash`;
+
+// Herdr (hash is derived from HERDR_SOCKET_PATH)
+`herdr.session_${hash}.targetPane.pane_${targetPaneId}.stash`;
 ```
 
 **Data Structure:**
@@ -465,10 +497,10 @@ All stash operations use the Conf library for persistent storage, regardless of 
 
 #### Workflow
 
-1. **Determine editor pane**: Reads `EDITPROMPT_MUX` environment variable to identify multiplexer type
+1. **Determine editor pane**: Uses `EDITPROMPT_MUX`, then detects Herdr from `HERDR_SOCKET_PATH` and the pane environment, and otherwise defaults to tmux
 2. **Get current pane ID**: Identifies the current pane as the editor pane
 3. **Verify editor pane**: Checks that the current pane is registered as an editor pane
-4. **Get target pane ID**: Retrieves target pane ID from pane variables (tmux) or Conf (WezTerm)
+4. **Get target pane ID**: Retrieves target pane ID from pane variables (tmux) or Conf (WezTerm/Herdr)
 5. **Perform stash operation**: Execute the requested subcommand (push/list/apply/drop/pop)
 
 #### Subcommand Details

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -14,3 +14,11 @@ export const TMUX_SEND_CHUNK_BYTES = TMUX_IMSG_LIMIT_BYTES / 2;
 // ARG_MAX (typically 256KB+) rather than imsg, so it has more headroom. Reuse
 // the same chunk size for simplicity and consistency.
 export const WEZTERM_SEND_CHUNK_BYTES = TMUX_SEND_CHUNK_BYTES;
+
+// Herdr v0.7.5's src/api/server.rs defines MAX_INITIAL_REQUEST_BYTES as 1MB
+// for the initial newline-delimited JSON request.
+// A control character can expand from one byte to six bytes when JSON-encoded,
+// so use one eighth of that limit for text and leave room for the request
+// envelope.
+const HERDR_REQUEST_LIMIT_BYTES = 1024 * 1024;
+export const HERDR_SEND_CHUNK_BYTES = HERDR_REQUEST_LIMIT_BYTES / 8;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { registerCommand } from "./modes/register";
 import { resumeCommand } from "./modes/resume";
 import { pressCommand } from "./modes/press";
 import { stashCommand } from "./modes/stash";
+import { toggleCommand } from "./modes/toggle";
 
 const argv = process.argv.slice(2);
 
@@ -45,6 +46,7 @@ await cli(
       open: openCommand,
       register: registerCommand,
       resume: resumeCommand,
+      toggle: toggleCommand,
       input: inputCommand,
       press: pressCommand,
       collect: collectCommand,

--- a/src/modes/args.ts
+++ b/src/modes/args.ts
@@ -1,12 +1,12 @@
 import { getLogger } from "@logtape/logtape";
 import type { ArgSchema } from "gunshi";
-import { type MuxType, SUPPORTED_MUXES, isMuxType } from "./common";
+import { type MuxType, resolveMux } from "../utils/mux";
 
 const logger = getLogger(["editprompt"]);
 
 export const ARG_MUX: ArgSchema = {
   short: "m",
-  description: "Multiplexer type (tmux or wezterm, default: tmux)",
+  description: "Multiplexer type (tmux, wezterm, or herdr; auto-detects Herdr, otherwise tmux)",
   type: "string",
 };
 
@@ -62,15 +62,20 @@ export const ARG_VERBOSE: ArgSchema = {
   type: "boolean",
 };
 
+export const ARG_ENV: ArgSchema = {
+  short: "E",
+  description: "Environment variables to set (e.g., KEY=VALUE)",
+  type: "string",
+  multiple: true,
+};
+
 export function validateMux(value: unknown): MuxType {
-  const muxValue = (value || "tmux") as string;
-  if (!isMuxType(muxValue)) {
-    logger.error(
-      `Invalid multiplexer type '${muxValue}'. Supported values: ${SUPPORTED_MUXES.join(", ")}`,
-    );
+  try {
+    return resolveMux(value);
+  } catch (error) {
+    logger.error(error instanceof Error ? error.message : String(error));
     process.exit(1);
   }
-  return muxValue;
 }
 
 export function validateTargetPane(value: unknown, commandName: string): string {

--- a/src/modes/collect.ts
+++ b/src/modes/collect.ts
@@ -1,5 +1,6 @@
 import { getLogger } from "@logtape/logtape";
 import { define } from "gunshi";
+import { appendToQuoteText as appendToHerdrQuoteText } from "../modules/herdr";
 import { appendToQuoteVariable } from "../modules/tmux";
 import { appendToQuoteText } from "../modules/wezterm";
 import { extractRawContent } from "../utils/argumentParser";
@@ -92,6 +93,8 @@ export async function runCollectMode(
           await appendToQuoteVariable(targetPaneId, processedText);
         } else if (mux === "wezterm") {
           await appendToQuoteText(targetPaneId, processedText);
+        } else {
+          await appendToHerdrQuoteText(targetPaneId, processedText);
         }
       } else if (output === "stdout") {
         process.stdout.write(processedText);
@@ -126,14 +129,14 @@ export const collectCommand = define({
     const outputs = normalizeCollectOutputs(ctx.values.output);
     const withQuote = !ctx.values["no-quote"];
 
-    // For wezterm, content must be provided as argument
+    // For WezTerm and Herdr, content must be provided as an argument.
     // For tmux, content is read from stdin
     let rawContent: string | undefined;
-    if (mux === "wezterm") {
+    if (mux === "wezterm" || mux === "herdr") {
       rawContent = extractRawContent(ctx.rest, ctx.positionals);
       if (rawContent === undefined) {
         logger.error(
-          'Text content is required for collect mode with wezterm. Use: editprompt collect --mux wezterm --target-pane <id> -- "<text>"',
+          `Text content is required for collect mode with ${mux}. Use: editprompt collect --mux ${mux} --target-pane <id> -- "<text>"`,
         );
         process.exit(1);
       }

--- a/src/modes/common.ts
+++ b/src/modes/common.ts
@@ -2,16 +2,12 @@ import { getLogger } from "@logtape/logtape";
 import clipboardy from "clipboardy";
 
 const logger = getLogger(["editprompt", "delivery"]);
+import { focusPane as focusHerdrPane, inputToHerdrPane } from "../modules/herdr";
 import { focusPane as focusTmuxPane, inputToTmuxPane } from "../modules/tmux";
 import { focusPane as focusWeztermPane, inputToWeztermPane } from "../modules/wezterm";
+import type { MuxType } from "../utils/mux";
 
-export type MuxType = "tmux" | "wezterm";
-
-export function isMuxType(value: unknown): value is MuxType {
-  return value === "tmux" || value === "wezterm";
-}
-
-export const SUPPORTED_MUXES: MuxType[] = ["tmux", "wezterm"];
+export type { MuxType } from "../utils/mux";
 
 export interface DeliveryResult {
   successCount: number;
@@ -32,6 +28,8 @@ async function inputContentToPane(
 ): Promise<void> {
   if (mux === "wezterm") {
     await inputToWeztermPane(targetPaneId, content);
+  } else if (mux === "herdr") {
+    await inputToHerdrPane(targetPaneId, content);
   } else {
     await inputToTmuxPane(targetPaneId, content);
   }
@@ -46,8 +44,10 @@ export async function focusFirstSuccessPane(
   if (firstSuccessPane) {
     if (mux === "tmux") {
       await focusTmuxPane(firstSuccessPane);
-    } else {
+    } else if (mux === "wezterm") {
       await focusWeztermPane(firstSuccessPane);
+    } else {
+      await focusHerdrPane(firstSuccessPane);
     }
   }
 }

--- a/src/modes/dump.ts
+++ b/src/modes/dump.ts
@@ -1,5 +1,6 @@
 import { getLogger } from "@logtape/logtape";
 import { define } from "gunshi";
+import * as herdr from "../modules/herdr";
 import { setupLogger } from "../modules/logger";
 import {
   clearQuoteVariable,
@@ -26,9 +27,12 @@ export async function runDumpMode(): Promise<void> {
     if (config.mux === "tmux") {
       currentPaneId = await getCurrentPaneId();
       isEditor = await isEditorPane(currentPaneId);
-    } else {
+    } else if (config.mux === "wezterm") {
       currentPaneId = await wezterm.getCurrentPaneId();
       isEditor = wezterm.isEditorPaneFromConf(currentPaneId);
+    } else {
+      currentPaneId = await herdr.getCurrentPaneId();
+      isEditor = herdr.isEditorPaneFromConf(currentPaneId);
     }
 
     if (!isEditor) {
@@ -40,8 +44,10 @@ export async function runDumpMode(): Promise<void> {
     let targetPanes: string[];
     if (config.mux === "tmux") {
       targetPanes = await getTargetPaneIds(currentPaneId);
-    } else {
+    } else if (config.mux === "wezterm") {
       targetPanes = await wezterm.getTargetPaneIds(currentPaneId);
+    } else {
+      targetPanes = await herdr.getTargetPaneIds(currentPaneId);
     }
 
     if (targetPanes.length === 0) {
@@ -56,9 +62,12 @@ export async function runDumpMode(): Promise<void> {
       if (config.mux === "tmux") {
         content = await getQuoteVariableContent(targetPane);
         await clearQuoteVariable(targetPane);
-      } else {
+      } else if (config.mux === "wezterm") {
         content = await wezterm.getQuoteText(targetPane);
         await wezterm.clearQuoteText(targetPane);
+      } else {
+        content = await herdr.getQuoteText(targetPane);
+        await herdr.clearQuoteText(targetPane);
       }
       if (content.trim() !== "") {
         quoteContents.push(content);

--- a/src/modes/input.ts
+++ b/src/modes/input.ts
@@ -1,5 +1,6 @@
 import { getLogger } from "@logtape/logtape";
 import { define } from "gunshi";
+import * as herdr from "../modules/herdr";
 import { setupLogger } from "../modules/logger";
 import {
   getCurrentPaneId,
@@ -39,9 +40,12 @@ export async function runInputMode(
   if (config.mux === "tmux") {
     currentPaneId = await getCurrentPaneId();
     isEditor = await isEditorPane(currentPaneId);
-  } else {
+  } else if (config.mux === "wezterm") {
     currentPaneId = await wezterm.getCurrentPaneId();
     isEditor = wezterm.isEditorPaneFromConf(currentPaneId);
+  } else {
+    currentPaneId = await herdr.getCurrentPaneId();
+    isEditor = herdr.isEditorPaneFromConf(currentPaneId);
   }
 
   if (!isEditor) {
@@ -53,8 +57,10 @@ export async function runInputMode(
   let targetPanes: string[];
   if (config.mux === "tmux") {
     targetPanes = await getTargetPaneIds(currentPaneId);
-  } else {
+  } else if (config.mux === "wezterm") {
     targetPanes = await wezterm.getTargetPaneIds(currentPaneId);
+  } else {
+    targetPanes = await herdr.getTargetPaneIds(currentPaneId);
   }
 
   if (targetPanes.length === 0) {
@@ -64,7 +70,8 @@ export async function runInputMode(
 
   // Auto-send mode
   if (autoSend) {
-    const key = sendKey || (config.mux === "wezterm" ? "\\r" : "C-m");
+    const key =
+      sendKey || (config.mux === "wezterm" ? "\\r" : config.mux === "herdr" ? "enter" : "C-m");
 
     const IMAGE_EXTENSIONS = /\.(png|webp|avif|jpe?g|gif)\b/i;
     const hasImagePath = IMAGE_EXTENSIONS.test(content);
@@ -76,6 +83,9 @@ export async function runInputMode(
         if (config.mux === "wezterm") {
           await wezterm.inputToWeztermPane(targetPane, content);
           await wezterm.sendKeyToWeztermPane(targetPane, key, delay);
+        } else if (config.mux === "herdr") {
+          await herdr.inputToHerdrPane(targetPane, content);
+          await herdr.sendKeyToHerdrPane(targetPane, key, delay);
         } else {
           await inputToTmuxPane(targetPane, content);
           await sendKeyToTmuxPane(targetPane, key, delay);

--- a/src/modes/openEditor.ts
+++ b/src/modes/openEditor.ts
@@ -1,6 +1,7 @@
 import { getLogger } from "@logtape/logtape";
 import { define } from "gunshi";
 import { openEditorAndGetContent } from "../modules/editor";
+import * as herdr from "../modules/herdr";
 import { setupLogger } from "../modules/logger";
 import { clearEditorPaneId, getCurrentPaneId, markAsEditorPane } from "../modules/tmux";
 import * as wezterm from "../modules/wezterm";
@@ -10,6 +11,7 @@ const logger = getLogger(["editprompt", "open"]);
 import {
   ARG_ALWAYS_COPY,
   ARG_EDITOR,
+  ARG_ENV,
   ARG_MUX,
   ARG_LOG_FILE,
   ARG_QUIET,
@@ -34,6 +36,8 @@ interface OpenEditorModeOptions {
 }
 
 export async function runOpenEditorMode(options: OpenEditorModeOptions): Promise<void> {
+  let herdrEditorPaneId: string | undefined;
+
   if (options.targetPanes.length > 0 && options.mux === "tmux") {
     try {
       const currentPaneId = await getCurrentPaneId();
@@ -45,6 +49,14 @@ export async function runOpenEditorMode(options: OpenEditorModeOptions): Promise
     try {
       const currentPaneId = await wezterm.getCurrentPaneId();
       await wezterm.markAsEditorPane(currentPaneId, options.targetPanes);
+    } catch {
+      //
+    }
+  } else if (options.targetPanes.length > 0 && options.mux === "herdr") {
+    try {
+      const currentPaneId = await herdr.getCurrentPaneId();
+      herdrEditorPaneId = currentPaneId;
+      await herdr.markAsEditorPane(currentPaneId, options.targetPanes);
     } catch {
       //
     }
@@ -109,6 +121,14 @@ export async function runOpenEditorMode(options: OpenEditorModeOptions): Promise
       } catch {
         //
       }
+    } else if (options.targetPanes.length > 0 && options.mux === "herdr") {
+      try {
+        for (const targetPane of options.targetPanes) {
+          await herdr.clearEditorPaneId(targetPane, herdrEditorPaneId);
+        }
+      } catch {
+        //
+      }
     }
   }
 }
@@ -124,12 +144,7 @@ export const openCommand = define({
     "log-file": ARG_LOG_FILE,
     quiet: ARG_QUIET,
     verbose: ARG_VERBOSE,
-    env: {
-      short: "E",
-      description: "Environment variables to set (e.g., KEY=VALUE)",
-      type: "string",
-      multiple: true,
-    },
+    env: ARG_ENV,
   },
   async run(ctx) {
     setupLogger({

--- a/src/modes/press.ts
+++ b/src/modes/press.ts
@@ -1,5 +1,6 @@
 import { getLogger } from "@logtape/logtape";
 import { define } from "gunshi";
+import * as herdr from "../modules/herdr";
 import { setupLogger } from "../modules/logger";
 import {
   getCurrentPaneId,
@@ -28,9 +29,12 @@ export async function runPressMode(key: string, delay = 0): Promise<void> {
   if (config.mux === "tmux") {
     currentPaneId = await getCurrentPaneId();
     isEditor = await isEditorPane(currentPaneId);
-  } else {
+  } else if (config.mux === "wezterm") {
     currentPaneId = await wezterm.getCurrentPaneId();
     isEditor = wezterm.isEditorPaneFromConf(currentPaneId);
+  } else {
+    currentPaneId = await herdr.getCurrentPaneId();
+    isEditor = herdr.isEditorPaneFromConf(currentPaneId);
   }
 
   if (!isEditor) {
@@ -41,8 +45,10 @@ export async function runPressMode(key: string, delay = 0): Promise<void> {
   let targetPanes: string[];
   if (config.mux === "tmux") {
     targetPanes = await getTargetPaneIds(currentPaneId);
-  } else {
+  } else if (config.mux === "wezterm") {
     targetPanes = await wezterm.getTargetPaneIds(currentPaneId);
+  } else {
+    targetPanes = await herdr.getTargetPaneIds(currentPaneId);
   }
 
   if (targetPanes.length === 0) {
@@ -55,6 +61,8 @@ export async function runPressMode(key: string, delay = 0): Promise<void> {
     try {
       if (config.mux === "wezterm") {
         await wezterm.sendKeyToWeztermPane(targetPane, key, delay);
+      } else if (config.mux === "herdr") {
+        await herdr.sendKeyToHerdrPane(targetPane, key, delay);
       } else {
         await sendKeyToTmuxPane(targetPane, key, delay);
       }

--- a/src/modes/register.ts
+++ b/src/modes/register.ts
@@ -1,5 +1,6 @@
 import { getLogger } from "@logtape/logtape";
 import { define } from "gunshi";
+import * as herdr from "../modules/herdr";
 import {
   getCurrentPaneId,
   getTargetPaneIds,
@@ -58,6 +59,15 @@ export async function runRegisterMode(options: RegisterModeOptions): Promise<voi
         );
         process.exit(1);
       }
+    } else if (options.mux === "herdr") {
+      editorPaneId = await herdr.getCurrentPaneId();
+      const isEditor = herdr.isEditorPaneFromConf(editorPaneId);
+      if (!isEditor) {
+        logger.error(
+          "Current pane is not an editor pane. Please run this command from an editor pane or specify --editor-pane.",
+        );
+        process.exit(1);
+      }
     } else {
       logger.error("Unsupported multiplexer");
       process.exit(1);
@@ -72,6 +82,8 @@ export async function runRegisterMode(options: RegisterModeOptions): Promise<voi
       existingPanes = await getTargetPaneIds(editorPaneId);
     } else if (options.mux === "wezterm") {
       existingPanes = await wezterm.getTargetPaneIds(editorPaneId);
+    } else if (options.mux === "herdr") {
+      existingPanes = await herdr.getTargetPaneIds(editorPaneId);
     }
 
     // Merge with new target panes and remove duplicates
@@ -82,6 +94,8 @@ export async function runRegisterMode(options: RegisterModeOptions): Promise<voi
       await markAsEditorPane(editorPaneId, mergedTargetPanes);
     } else if (options.mux === "wezterm") {
       await wezterm.markAsEditorPane(editorPaneId, mergedTargetPanes);
+    } else if (options.mux === "herdr") {
+      await herdr.markAsEditorPane(editorPaneId, mergedTargetPanes);
     }
 
     logger.info(

--- a/src/modes/resume.ts
+++ b/src/modes/resume.ts
@@ -1,5 +1,6 @@
 import { getLogger } from "@logtape/logtape";
 import { define } from "gunshi";
+import * as herdr from "../modules/herdr";
 import {
   checkPaneExists,
   clearEditorPaneId,
@@ -25,6 +26,15 @@ import type { MuxType } from "./common";
 const logger = getLogger(["editprompt", "resume"]);
 
 export async function runResumeMode(targetPane: string, mux: MuxType): Promise<void> {
+  if (mux === "herdr") {
+    try {
+      process.exit((await herdr.resumeEditorPane(targetPane)) ? 0 : 1);
+    } catch (error) {
+      logger.debug("Herdr resume failed: {error}", { error });
+      process.exit(1);
+    }
+  }
+
   if (mux === "wezterm") {
     const currentPaneId = await wezterm.getCurrentPaneId();
     const isEditor = wezterm.isEditorPaneFromConf(currentPaneId);

--- a/src/modes/stash.ts
+++ b/src/modes/stash.ts
@@ -1,6 +1,7 @@
 import { getLogger } from "@logtape/logtape";
 import { define } from "gunshi";
 import { conf } from "../modules/conf";
+import * as herdr from "../modules/herdr";
 import { setupLogger } from "../modules/logger";
 import { getCurrentPaneId, getTargetPaneIds, isEditorPane } from "../modules/tmux";
 import * as wezterm from "../modules/wezterm";
@@ -13,7 +14,8 @@ const logger = getLogger(["editprompt", "stash"]);
 
 // Stash storage key helper
 function getStashKey(mux: MuxType, targetPaneId: string): string {
-  return `${mux}.targetPane.pane_${targetPaneId}.stash`;
+  const namespace = mux === "herdr" ? herdr.getStorageNamespace() : mux;
+  return `${namespace}.targetPane.pane_${targetPaneId}.stash`;
 }
 
 // Stash data type
@@ -105,9 +107,12 @@ async function getTargetPaneForStash(): Promise<{
   if (config.mux === "tmux") {
     currentPaneId = await getCurrentPaneId();
     isEditor = await isEditorPane(currentPaneId);
-  } else {
+  } else if (config.mux === "wezterm") {
     currentPaneId = await wezterm.getCurrentPaneId();
     isEditor = wezterm.isEditorPaneFromConf(currentPaneId);
+  } else {
+    currentPaneId = await herdr.getCurrentPaneId();
+    isEditor = herdr.isEditorPaneFromConf(currentPaneId);
   }
 
   if (!isEditor) {
@@ -119,8 +124,10 @@ async function getTargetPaneForStash(): Promise<{
   let targetPanes: string[];
   if (config.mux === "tmux") {
     targetPanes = await getTargetPaneIds(currentPaneId);
-  } else {
+  } else if (config.mux === "wezterm") {
     targetPanes = await wezterm.getTargetPaneIds(currentPaneId);
+  } else {
+    targetPanes = await herdr.getTargetPaneIds(currentPaneId);
   }
 
   if (targetPanes.length === 0) {

--- a/src/modes/toggle.ts
+++ b/src/modes/toggle.ts
@@ -1,0 +1,169 @@
+import { getLogger } from "@logtape/logtape";
+import { define } from "gunshi";
+import * as herdr from "../modules/herdr";
+import { setupLogger } from "../modules/logger";
+import type { MuxType } from "../utils/mux";
+import {
+  ARG_ALWAYS_COPY,
+  ARG_EDITOR,
+  ARG_ENV,
+  ARG_LOG_FILE,
+  ARG_MUX,
+  ARG_QUIET,
+  ARG_TARGET_PANE_SINGLE,
+  ARG_VERBOSE,
+  validateMux,
+  validateTargetPane,
+} from "./args";
+
+const logger = getLogger(["editprompt", "toggle"]);
+const DEFAULT_EDITOR_PANE_ROWS = 12;
+
+interface EditpromptInvocation {
+  execPath: string;
+  scriptPath: string;
+}
+
+export interface ToggleModeOptions {
+  mux: MuxType;
+  targetPane: string;
+  paneRows: number;
+  alwaysCopy: boolean;
+  editor?: string;
+  env?: string[];
+  logFile?: string;
+  quiet: boolean;
+  verbose: boolean;
+  invocation?: EditpromptInvocation;
+}
+
+type ToggleHerdrApi = Pick<
+  typeof herdr,
+  "closePane" | "resumeEditorPane" | "runCommandInPane" | "splitEditorPane"
+>;
+
+export function buildOpenEditorArgv(options: ToggleModeOptions): string[] {
+  const invocation = options.invocation ?? {
+    execPath: process.execPath,
+    scriptPath: process.argv[1],
+  };
+  if (!invocation.scriptPath) {
+    throw new Error("Cannot determine the editprompt entrypoint");
+  }
+
+  const argv = [
+    invocation.execPath,
+    invocation.scriptPath,
+    "open",
+    "--mux",
+    options.mux,
+    "--target-pane",
+    options.targetPane,
+  ];
+  if (options.editor) {
+    argv.push("--editor", options.editor);
+  }
+  if (options.alwaysCopy) {
+    argv.push("--always-copy");
+  }
+  for (const env of options.env ?? []) {
+    argv.push("--env", env);
+  }
+  if (options.logFile) {
+    argv.push("--log-file", options.logFile);
+  }
+  if (options.quiet) {
+    argv.push("--quiet");
+  }
+  if (options.verbose) {
+    argv.push("--verbose");
+  }
+  return argv;
+}
+
+export async function runToggleMode(
+  options: ToggleModeOptions,
+  herdrApi: ToggleHerdrApi = herdr,
+): Promise<void> {
+  if (options.mux !== "herdr") {
+    throw new Error("toggle currently supports only the Herdr multiplexer");
+  }
+  if (!Number.isInteger(options.paneRows) || options.paneRows <= 0) {
+    throw new Error("--pane-rows must be a positive integer");
+  }
+
+  if (await herdrApi.resumeEditorPane(options.targetPane)) {
+    return;
+  }
+
+  // The split pane starts with a fresh shell environment, so Node runtime
+  // warnings would reappear in the editor pane unless this is carried over.
+  const launchEnv: Record<string, string> = {};
+  if (process.env.NODE_NO_WARNINGS !== undefined) {
+    launchEnv.NODE_NO_WARNINGS = process.env.NODE_NO_WARNINGS;
+  }
+
+  const editorPaneId = await herdrApi.splitEditorPane(
+    options.targetPane,
+    options.paneRows,
+    process.env.HERDR_ACTIVE_PANE_CWD,
+    launchEnv,
+  );
+  try {
+    await herdrApi.runCommandInPane(editorPaneId, buildOpenEditorArgv(options));
+  } catch (error) {
+    try {
+      await herdrApi.closePane(editorPaneId);
+    } catch (closeError) {
+      logger.warn("Failed to close editor pane after launch failure: {error}", {
+        error: closeError,
+      });
+    }
+    throw error;
+  }
+}
+
+export const toggleCommand = define({
+  name: "toggle",
+  description: "Open or focus an editor pane",
+  args: {
+    mux: ARG_MUX,
+    "target-pane": ARG_TARGET_PANE_SINGLE,
+    "pane-rows": {
+      description: "Desired rows for the Herdr editor pane",
+      type: "number",
+      default: DEFAULT_EDITOR_PANE_ROWS,
+    },
+    editor: ARG_EDITOR,
+    "always-copy": ARG_ALWAYS_COPY,
+    env: ARG_ENV,
+    "log-file": ARG_LOG_FILE,
+    quiet: ARG_QUIET,
+    verbose: ARG_VERBOSE,
+  },
+  async run(ctx) {
+    const logFile = ctx.values["log-file"] as string | undefined;
+    const quiet = Boolean(ctx.values.quiet);
+    const verbose = Boolean(ctx.values.verbose);
+    setupLogger({ quiet, verbose, logFile });
+
+    const targetPane = validateTargetPane(ctx.values["target-pane"], "toggle");
+    const mux = validateMux(ctx.values.mux);
+    try {
+      await runToggleMode({
+        mux,
+        targetPane,
+        paneRows: Number(ctx.values["pane-rows"]),
+        alwaysCopy: Boolean(ctx.values["always-copy"]),
+        editor: ctx.values.editor as string | undefined,
+        env: ctx.values.env as string[] | undefined,
+        logFile,
+        quiet,
+        verbose,
+      });
+    } catch (error) {
+      logger.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+  },
+});

--- a/src/modules/herdr.ts
+++ b/src/modules/herdr.ts
@@ -1,0 +1,382 @@
+import { createHash } from "node:crypto";
+import { createConnection } from "node:net";
+import { getLogger } from "@logtape/logtape";
+import { HERDR_SEND_CHUNK_BYTES } from "../config/constants";
+import { splitByByteSize } from "../utils/contentChunker";
+import { conf } from "./conf";
+
+const logger = getLogger(["editprompt", "herdr"]);
+const HERDR_REQUEST_TIMEOUT_MS = 6_000;
+let requestSequence = 0;
+
+interface HerdrError {
+  code: string;
+  message: string;
+}
+
+interface HerdrResponse {
+  id: string;
+  result?: unknown;
+  error?: HerdrError;
+}
+
+interface HerdrPaneLayoutResult {
+  layout?: {
+    panes?: Array<{
+      pane_id?: unknown;
+      rect?: {
+        height?: unknown;
+      };
+    }>;
+  };
+}
+
+interface HerdrPaneInfoResult {
+  pane?: {
+    pane_id?: unknown;
+  };
+}
+
+function getSocketPath(): string {
+  const socketPath = process.env.HERDR_SOCKET_PATH?.trim();
+  if (!socketPath) {
+    throw new Error("HERDR_SOCKET_PATH is not set");
+  }
+  return socketPath;
+}
+
+async function sendRequest(method: string, params: Record<string, unknown>): Promise<unknown> {
+  const id = `editprompt_${process.pid}_${++requestSequence}`;
+  const request = `${JSON.stringify({ id, method, params })}\n`;
+
+  return new Promise((resolve, reject) => {
+    const socket = createConnection(getSocketPath());
+    let buffer = "";
+    let settled = false;
+
+    const finish = (callback: () => void): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      socket.end();
+      callback();
+    };
+
+    socket.setEncoding("utf8");
+    socket.setTimeout(HERDR_REQUEST_TIMEOUT_MS);
+    socket.on("connect", () => {
+      socket.write(request);
+    });
+    socket.on("data", (chunk: string) => {
+      buffer += chunk;
+      const newlineIndex = buffer.indexOf("\n");
+      if (newlineIndex === -1) {
+        return;
+      }
+
+      const line = buffer.slice(0, newlineIndex);
+      let response: HerdrResponse;
+      try {
+        response = JSON.parse(line) as HerdrResponse;
+      } catch (error) {
+        finish(() => {
+          reject(
+            new Error(
+              `Invalid response from Herdr: ${error instanceof Error ? error.message : "Unknown error"}`,
+            ),
+          );
+        });
+        return;
+      }
+
+      if (response.id !== id) {
+        finish(() => {
+          reject(new Error(`Unexpected response ID from Herdr: ${response.id}`));
+        });
+        return;
+      }
+      if (response.error) {
+        finish(() => {
+          reject(new Error(`Herdr ${response.error?.code}: ${response.error?.message}`));
+        });
+        return;
+      }
+
+      finish(() => {
+        resolve(response.result);
+      });
+    });
+    socket.on("error", (error) => {
+      finish(() => {
+        reject(new Error(`Failed to communicate with Herdr: ${error.message}`));
+      });
+    });
+    socket.on("timeout", () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      socket.destroy();
+      reject(new Error(`Timed out waiting for Herdr response after ${HERDR_REQUEST_TIMEOUT_MS}ms`));
+    });
+    socket.on("end", () => {
+      if (!settled) {
+        finish(() => {
+          reject(new Error("Herdr closed the socket before sending a response"));
+        });
+      }
+    });
+  });
+}
+
+export function getStorageNamespace(): string {
+  const sessionHash = createHash("sha256").update(getSocketPath()).digest("hex").slice(0, 16);
+  return `herdr.session_${sessionHash}`;
+}
+
+function targetPaneKey(paneId: string): string {
+  return `${getStorageNamespace()}.targetPane.pane_${paneId}`;
+}
+
+function editorPaneKey(paneId: string): string {
+  return `${getStorageNamespace()}.editorPane.pane_${paneId}`;
+}
+
+export async function getCurrentPaneId(): Promise<string> {
+  const paneId = process.env.HERDR_PANE_ID?.trim() || process.env.HERDR_ACTIVE_PANE_ID?.trim();
+  if (!paneId) {
+    throw new Error("HERDR_PANE_ID or HERDR_ACTIVE_PANE_ID is not set");
+  }
+  return paneId;
+}
+
+export async function checkPaneExists(paneId: string): Promise<boolean> {
+  try {
+    await sendRequest("pane.get", { pane_id: paneId });
+    return true;
+  } catch (error) {
+    logger.debug("checkPaneExists failed: {error}", { error });
+    return false;
+  }
+}
+
+export async function focusPane(paneId: string): Promise<void> {
+  await sendRequest("pane.focus", { pane_id: paneId });
+}
+
+export function calculateEditorSplitRatio(paneHeight: number, editorPaneRows: number): number {
+  if (!Number.isInteger(paneHeight) || paneHeight <= 1) {
+    throw new Error(`Invalid Herdr pane height: ${paneHeight}`);
+  }
+  if (!Number.isInteger(editorPaneRows) || editorPaneRows <= 0) {
+    throw new Error(`Invalid Herdr editor pane rows: ${editorPaneRows}`);
+  }
+
+  return Math.min(0.9, Math.max(0.1, 1 - editorPaneRows / paneHeight));
+}
+
+export async function splitEditorPane(
+  targetPaneId: string,
+  editorPaneRows: number,
+  cwd?: string,
+  env: Record<string, string> = {},
+): Promise<string> {
+  const layoutResult = (await sendRequest("pane.layout", {
+    pane_id: targetPaneId,
+  })) as HerdrPaneLayoutResult;
+  const targetPane = layoutResult.layout?.panes?.find((pane) => pane.pane_id === targetPaneId);
+  const paneHeight = targetPane?.rect?.height;
+  if (typeof paneHeight !== "number") {
+    throw new Error(`Herdr pane.layout did not return a height for pane ${targetPaneId}`);
+  }
+
+  const ratio = calculateEditorSplitRatio(paneHeight, editorPaneRows);
+  const params: Record<string, unknown> = {
+    target_pane_id: targetPaneId,
+    direction: "down",
+    ratio,
+    focus: true,
+    env,
+  };
+  if (cwd?.trim()) {
+    params.cwd = cwd;
+  }
+
+  const splitResult = (await sendRequest("pane.split", params)) as HerdrPaneInfoResult;
+  const editorPaneId = splitResult.pane?.pane_id;
+  if (typeof editorPaneId !== "string" || editorPaneId === "") {
+    throw new Error("Herdr pane.split did not return the new pane ID");
+  }
+  return editorPaneId;
+}
+
+function quoteShellWord(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+export async function runCommandInPane(paneId: string, argv: string[]): Promise<void> {
+  if (argv.length === 0) {
+    throw new Error("Cannot run an empty command in a Herdr pane");
+  }
+  const command = `exec ${argv.map(quoteShellWord).join(" ")}`;
+  await sendRequest("pane.send_input", {
+    pane_id: paneId,
+    text: command,
+    keys: ["Enter"],
+  });
+}
+
+export async function closePane(paneId: string): Promise<void> {
+  await sendRequest("pane.close", { pane_id: paneId });
+}
+
+export async function inputToHerdrPane(paneId: string, content: string): Promise<void> {
+  const chunks = splitByByteSize(content, HERDR_SEND_CHUNK_BYTES);
+  for (const chunk of chunks) {
+    await sendRequest("pane.send_text", { pane_id: paneId, text: chunk });
+  }
+  logger.debug("Content sent to Herdr pane: {paneId} ({chunkCount} chunks)", {
+    paneId,
+    chunkCount: chunks.length,
+  });
+}
+
+export async function sendKeyToHerdrPane(paneId: string, key: string, delay = 1000): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, delay));
+  await sendRequest("pane.send_keys", { pane_id: paneId, keys: [key] });
+}
+
+export async function saveEditorPaneId(targetPaneId: string, editorPaneId: string): Promise<void> {
+  const data = conf.get(targetPaneKey(targetPaneId));
+  const existing = typeof data === "object" && data !== null ? data : {};
+  conf.set(targetPaneKey(targetPaneId), {
+    ...existing,
+    editorPaneId,
+  });
+}
+
+export async function getEditorPaneId(targetPaneId: string): Promise<string> {
+  const data = conf.get(targetPaneKey(targetPaneId));
+  if (typeof data === "object" && data !== null && "editorPaneId" in data) {
+    return String(data.editorPaneId);
+  }
+  return "";
+}
+
+export async function clearEditorPaneId(
+  targetPaneId: string,
+  expectedEditorPaneId?: string,
+): Promise<void> {
+  const editorPaneId = await getEditorPaneId(targetPaneId);
+  if (expectedEditorPaneId && editorPaneId !== expectedEditorPaneId) {
+    conf.delete(editorPaneKey(expectedEditorPaneId));
+    return;
+  }
+
+  const data = conf.get(targetPaneKey(targetPaneId));
+  if (typeof data === "object" && data !== null && "editorPaneId" in data) {
+    const { editorPaneId: _, ...remaining } = data;
+    if (Object.keys(remaining).length === 0) {
+      conf.delete(targetPaneKey(targetPaneId));
+    } else {
+      conf.set(targetPaneKey(targetPaneId), remaining);
+    }
+  }
+  if (editorPaneId) {
+    conf.delete(editorPaneKey(editorPaneId));
+  }
+}
+
+export async function markAsEditorPane(
+  editorPaneId: string,
+  targetPaneIds: string[],
+): Promise<void> {
+  const uniqueTargetPaneIds = [...new Set(targetPaneIds)];
+  conf.set(editorPaneKey(editorPaneId), {
+    targetPaneIds: uniqueTargetPaneIds,
+  });
+  for (const targetPaneId of uniqueTargetPaneIds) {
+    await saveEditorPaneId(targetPaneId, editorPaneId);
+  }
+}
+
+export async function getTargetPaneIds(editorPaneId: string): Promise<string[]> {
+  const data = conf.get(editorPaneKey(editorPaneId));
+  if (typeof data === "object" && data !== null && "targetPaneIds" in data) {
+    const targetPaneIds = data.targetPaneIds;
+    if (Array.isArray(targetPaneIds)) {
+      return targetPaneIds.map((id) => String(id));
+    }
+  }
+  return [];
+}
+
+export function isEditorPaneFromConf(paneId: string): boolean {
+  return conf.has(editorPaneKey(paneId));
+}
+
+export async function resumeEditorPane(targetPaneId: string): Promise<boolean> {
+  const currentPaneId = await getCurrentPaneId();
+  const editorPaneId = isEditorPaneFromConf(currentPaneId)
+    ? currentPaneId
+    : isEditorPaneFromConf(targetPaneId)
+      ? targetPaneId
+      : "";
+
+  if (editorPaneId) {
+    const targetPaneIds = await getTargetPaneIds(editorPaneId);
+    for (const paneId of targetPaneIds) {
+      if (await checkPaneExists(paneId)) {
+        await focusPane(paneId);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  const registeredEditorPaneId = await getEditorPaneId(targetPaneId);
+  if (registeredEditorPaneId === "") {
+    return false;
+  }
+  if (!(await checkPaneExists(registeredEditorPaneId))) {
+    await clearEditorPaneId(targetPaneId);
+    return false;
+  }
+
+  await focusPane(registeredEditorPaneId);
+  return true;
+}
+
+export async function appendToQuoteText(paneId: string, content: string): Promise<void> {
+  const data = conf.get(targetPaneKey(paneId));
+  const existing = typeof data === "object" && data !== null ? data : {};
+  const existingQuoteText = "quote_text" in existing ? String(existing.quote_text) : "";
+  const quoteText =
+    existingQuoteText.trim() !== "" ? `${existingQuoteText}\n\n${content}` : content;
+
+  conf.set(targetPaneKey(paneId), {
+    ...existing,
+    quote_text: quoteText,
+  });
+}
+
+export async function getQuoteText(paneId: string): Promise<string> {
+  const data = conf.get(targetPaneKey(paneId));
+  if (typeof data === "object" && data !== null && "quote_text" in data) {
+    return String(data.quote_text);
+  }
+  return "";
+}
+
+export async function clearQuoteText(paneId: string): Promise<void> {
+  const data = conf.get(targetPaneKey(paneId));
+  if (typeof data === "object" && data !== null && "quote_text" in data) {
+    const { quote_text: _, ...remaining } = data;
+    if (Object.keys(remaining).length === 0) {
+      conf.delete(targetPaneKey(paneId));
+    } else {
+      conf.set(targetPaneKey(paneId), remaining);
+    }
+  }
+}

--- a/src/utils/mux.ts
+++ b/src/utils/mux.ts
@@ -1,0 +1,32 @@
+export type MuxType = "tmux" | "wezterm" | "herdr";
+
+export const SUPPORTED_MUXES: MuxType[] = ["tmux", "wezterm", "herdr"];
+
+export function isMuxType(value: unknown): value is MuxType {
+  return value === "tmux" || value === "wezterm" || value === "herdr";
+}
+
+function hasValue(value: string | undefined): boolean {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+export function isHerdrEnvironment(env: NodeJS.ProcessEnv = process.env): boolean {
+  return (
+    hasValue(env.HERDR_SOCKET_PATH) &&
+    (hasValue(env.HERDR_PANE_ID) || hasValue(env.HERDR_ACTIVE_PANE_ID))
+  );
+}
+
+export function resolveMux(explicitMux?: unknown, env: NodeJS.ProcessEnv = process.env): MuxType {
+  const muxValue =
+    explicitMux || env.EDITPROMPT_MUX || (isHerdrEnvironment(env) ? "herdr" : "tmux");
+
+  if (!isMuxType(muxValue)) {
+    const displayValue = typeof muxValue === "string" ? muxValue : `<${typeof muxValue}>`;
+    throw new Error(
+      `Invalid multiplexer type '${displayValue}'. Supported values: ${SUPPORTED_MUXES.join(", ")}`,
+    );
+  }
+
+  return muxValue;
+}

--- a/src/utils/sendConfig.ts
+++ b/src/utils/sendConfig.ts
@@ -1,18 +1,8 @@
-import type { MuxType } from "../modes/common";
 import type { SendConfig } from "../types/send";
-
-const VALID_MUX_TYPES = ["tmux", "wezterm"] as const;
+import { resolveMux } from "./mux";
 
 export function readSendConfig(): SendConfig {
-  const muxValue = process.env.EDITPROMPT_MUX || "tmux";
-
-  if (!VALID_MUX_TYPES.includes(muxValue as MuxType)) {
-    throw new Error(
-      `Invalid EDITPROMPT_MUX value: ${muxValue}. Must be one of: ${VALID_MUX_TYPES.join(", ")}`,
-    );
-  }
-
-  const mux = muxValue as MuxType;
+  const mux = resolveMux();
   const alwaysCopy = process.env.EDITPROMPT_ALWAYS_COPY === "1";
 
   const delayValue = process.env.EDITPROMPT_SEND_KEY_DELAY;

--- a/test/modes/stash.test.ts
+++ b/test/modes/stash.test.ts
@@ -30,6 +30,28 @@ describe("pushStash", () => {
     const data = conf.get(`${mux}.targetPane.pane_${targetPaneId}.stash`);
     expect(data).toEqual({ [key1]: content1, [key2]: content2 });
   });
+
+  test("should isolate Herdr stashes between sessions", async () => {
+    const originalSocketPath = process.env.HERDR_SOCKET_PATH;
+    try {
+      process.env.HERDR_SOCKET_PATH = "/tmp/herdr-session-a.sock";
+      await pushStash("herdr", "w1:p1", "session a");
+
+      process.env.HERDR_SOCKET_PATH = "/tmp/herdr-session-b.sock";
+      await pushStash("herdr", "w1:p1", "session b");
+
+      expect(getStashContent("herdr", "w1:p1")).toBe("session b");
+
+      process.env.HERDR_SOCKET_PATH = "/tmp/herdr-session-a.sock";
+      expect(getStashContent("herdr", "w1:p1")).toBe("session a");
+    } finally {
+      if (originalSocketPath === undefined) {
+        delete process.env.HERDR_SOCKET_PATH;
+      } else {
+        process.env.HERDR_SOCKET_PATH = originalSocketPath;
+      }
+    }
+  });
 });
 
 describe("getStashList", () => {

--- a/test/modes/toggle.test.ts
+++ b/test/modes/toggle.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, mock, test } from "bun:test";
+import { buildOpenEditorArgv, runToggleMode, type ToggleModeOptions } from "../../src/modes/toggle";
+
+function createOptions(overrides: Partial<ToggleModeOptions> = {}): ToggleModeOptions {
+  return {
+    mux: "herdr",
+    targetPane: "w1:p1",
+    paneRows: 12,
+    alwaysCopy: true,
+    editor: "nvim",
+    env: ["NVIM_NOTTYFAST=1"],
+    quiet: true,
+    verbose: false,
+    invocation: {
+      execPath: "/usr/local/bin/node",
+      scriptPath: "/repo with spaces/dist/index.js",
+    },
+    ...overrides,
+  };
+}
+
+describe("toggle mode", () => {
+  test("builds an open command using the current editprompt entrypoint", () => {
+    expect(buildOpenEditorArgv(createOptions())).toEqual([
+      "/usr/local/bin/node",
+      "/repo with spaces/dist/index.js",
+      "open",
+      "--mux",
+      "herdr",
+      "--target-pane",
+      "w1:p1",
+      "--editor",
+      "nvim",
+      "--always-copy",
+      "--env",
+      "NVIM_NOTTYFAST=1",
+      "--quiet",
+    ]);
+  });
+
+  test("focuses an existing editor without creating a split", async () => {
+    const resumeEditorPane = mock(async () => true);
+    const splitEditorPane = mock(async () => "w1:p2");
+    const runCommandInPane = mock(async () => {});
+    const closePane = mock(async () => {});
+
+    await runToggleMode(createOptions(), {
+      resumeEditorPane,
+      splitEditorPane,
+      runCommandInPane,
+      closePane,
+    });
+
+    expect(resumeEditorPane).toHaveBeenCalledWith("w1:p1");
+    expect(splitEditorPane).not.toHaveBeenCalled();
+    expect(runCommandInPane).not.toHaveBeenCalled();
+  });
+
+  test("creates a bottom split and runs open when no editor exists", async () => {
+    const originalCwd = process.env.HERDR_ACTIVE_PANE_CWD;
+    const originalNodeWarnings = process.env.NODE_NO_WARNINGS;
+    process.env.HERDR_ACTIVE_PANE_CWD = "/repo";
+    process.env.NODE_NO_WARNINGS = "1";
+
+    const resumeEditorPane = mock(async () => false);
+    const splitEditorPane = mock(async () => "w1:p2");
+    const runCommandInPane = mock(async () => {});
+    const closePane = mock(async () => {});
+
+    try {
+      const options = createOptions();
+      await runToggleMode(options, {
+        resumeEditorPane,
+        splitEditorPane,
+        runCommandInPane,
+        closePane,
+      });
+
+      expect(splitEditorPane).toHaveBeenCalledWith("w1:p1", 12, "/repo", {
+        NODE_NO_WARNINGS: "1",
+      });
+      expect(runCommandInPane).toHaveBeenCalledWith("w1:p2", buildOpenEditorArgv(options));
+      expect(closePane).not.toHaveBeenCalled();
+    } finally {
+      if (originalCwd === undefined) {
+        delete process.env.HERDR_ACTIVE_PANE_CWD;
+      } else {
+        process.env.HERDR_ACTIVE_PANE_CWD = originalCwd;
+      }
+      if (originalNodeWarnings === undefined) {
+        delete process.env.NODE_NO_WARNINGS;
+      } else {
+        process.env.NODE_NO_WARNINGS = originalNodeWarnings;
+      }
+    }
+  });
+
+  test("closes a newly-created pane when command launch fails", async () => {
+    const launchError = new Error("launch failed");
+    const closePane = mock(async () => {});
+
+    let thrown: unknown;
+    try {
+      await runToggleMode(createOptions(), {
+        resumeEditorPane: mock(async () => false),
+        splitEditorPane: mock(async () => "w1:p2"),
+        runCommandInPane: mock(async () => {
+          throw launchError;
+        }),
+        closePane,
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBe(launchError);
+    expect(closePane).toHaveBeenCalledWith("w1:p2");
+  });
+
+  test("rejects unsupported multiplexers and invalid row counts", async () => {
+    let muxError: unknown;
+    let rowsError: unknown;
+    try {
+      await runToggleMode(createOptions({ mux: "tmux" }));
+    } catch (error) {
+      muxError = error;
+    }
+    try {
+      await runToggleMode(createOptions({ paneRows: 0 }));
+    } catch (error) {
+      rowsError = error;
+    }
+
+    expect(muxError).toBeInstanceOf(Error);
+    expect((muxError as Error).message).toBe(
+      "toggle currently supports only the Herdr multiplexer",
+    );
+    expect(rowsError).toBeInstanceOf(Error);
+    expect((rowsError as Error).message).toBe("--pane-rows must be a positive integer");
+  });
+});

--- a/test/modules/herdr.test.ts
+++ b/test/modules/herdr.test.ts
@@ -1,0 +1,335 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer, type Server } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { HERDR_SEND_CHUNK_BYTES } from "../../src/config/constants";
+import { conf } from "../../src/modules/conf";
+import {
+  appendToQuoteText,
+  calculateEditorSplitRatio,
+  checkPaneExists,
+  closePane,
+  clearEditorPaneId,
+  clearQuoteText,
+  focusPane,
+  getCurrentPaneId,
+  getEditorPaneId,
+  getQuoteText,
+  getTargetPaneIds,
+  inputToHerdrPane,
+  isEditorPaneFromConf,
+  markAsEditorPane,
+  resumeEditorPane,
+  runCommandInPane,
+  sendKeyToHerdrPane,
+  splitEditorPane,
+} from "../../src/modules/herdr";
+
+interface HerdrRequest {
+  id: string;
+  method: string;
+  params: Record<string, unknown>;
+}
+
+let server: Server | undefined;
+let tempDirectory: string | undefined;
+let originalEnv: NodeJS.ProcessEnv;
+
+async function startServer(
+  handler: (request: HerdrRequest) => Record<string, unknown>,
+): Promise<HerdrRequest[]> {
+  tempDirectory = await mkdtemp(join(tmpdir(), "editprompt-herdr-test-"));
+  const socketPath = join(tempDirectory, "herdr.sock");
+  const requests: HerdrRequest[] = [];
+
+  server = createServer((socket) => {
+    socket.setEncoding("utf8");
+    let buffer = "";
+    socket.on("data", (chunk: string) => {
+      buffer += chunk;
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line) {
+          continue;
+        }
+        const request = JSON.parse(line) as HerdrRequest;
+        requests.push(request);
+        socket.write(`${JSON.stringify({ id: request.id, ...handler(request) })}\n`);
+      }
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server?.once("error", reject);
+    server?.listen(socketPath, resolve);
+  });
+  process.env.HERDR_SOCKET_PATH = socketPath;
+  return requests;
+}
+
+beforeEach(() => {
+  originalEnv = { ...process.env };
+  process.env.HERDR_SOCKET_PATH = "/tmp/editprompt-herdr-test.sock";
+  conf.clear();
+});
+
+afterEach(async () => {
+  process.env = originalEnv;
+  if (server) {
+    await new Promise<void>((resolve, reject) => {
+      server?.close((error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+    server = undefined;
+  }
+  if (tempDirectory) {
+    await rm(tempDirectory, { recursive: true });
+    tempDirectory = undefined;
+  }
+});
+
+describe("Herdr pane API", () => {
+  test("gets the current pane ID from a Herdr pane environment", async () => {
+    process.env.HERDR_PANE_ID = "w1:p2";
+
+    expect(await getCurrentPaneId()).toBe("w1:p2");
+  });
+
+  test("gets the active pane ID from a detached Herdr command", async () => {
+    delete process.env.HERDR_PANE_ID;
+    process.env.HERDR_ACTIVE_PANE_ID = "w1:p3";
+
+    expect(await getCurrentPaneId()).toBe("w1:p3");
+  });
+
+  test("throws when the current pane ID is unavailable", async () => {
+    delete process.env.HERDR_PANE_ID;
+    delete process.env.HERDR_ACTIVE_PANE_ID;
+
+    let thrown: unknown;
+    try {
+      await getCurrentPaneId();
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toBe("HERDR_PANE_ID or HERDR_ACTIVE_PANE_ID is not set");
+  });
+
+  test("checks pane existence through pane.get", async () => {
+    const requests = await startServer(() => ({
+      result: { type: "pane_info", pane: { pane_id: "w1:p2" } },
+    }));
+
+    expect(await checkPaneExists("w1:p2")).toBe(true);
+    expect(requests[0]).toMatchObject({
+      method: "pane.get",
+      params: { pane_id: "w1:p2" },
+    });
+  });
+
+  test("returns false when pane.get returns an error", async () => {
+    await startServer(() => ({
+      error: { code: "pane_not_found", message: "pane not found" },
+    }));
+
+    expect(await checkPaneExists("w1:p9")).toBe(false);
+  });
+
+  test("focuses a pane through pane.focus", async () => {
+    const requests = await startServer(() => ({ result: { type: "pane_info" } }));
+
+    await focusPane("w1:p2");
+
+    expect(requests[0]).toMatchObject({
+      method: "pane.focus",
+      params: { pane_id: "w1:p2" },
+    });
+  });
+
+  test("sends text and keys without shell escaping", async () => {
+    const requests = await startServer(() => ({ result: { type: "ok" } }));
+    const content = "hello 'herdr'\n日本語";
+
+    await inputToHerdrPane("w1:p2", content);
+    await sendKeyToHerdrPane("w1:p2", "enter", 0);
+
+    expect(requests[0]).toMatchObject({
+      method: "pane.send_text",
+      params: { pane_id: "w1:p2", text: content },
+    });
+    expect(requests[1]).toMatchObject({
+      method: "pane.send_keys",
+      params: { pane_id: "w1:p2", keys: ["enter"] },
+    });
+  });
+
+  test("splits text across requests below Herdr's request limit", async () => {
+    const requests = await startServer(() => ({ result: { type: "ok" } }));
+    const content = `先頭${"a".repeat(HERDR_SEND_CHUNK_BYTES)}末尾`;
+
+    await inputToHerdrPane("w1:p2", content);
+
+    expect(requests.length).toBeGreaterThan(1);
+    expect(requests.every((request) => request.method === "pane.send_text")).toBe(true);
+    expect(requests.map((request) => String(request.params.text)).join("")).toBe(content);
+  });
+
+  test("calculates a 12-row editor split within Herdr ratio limits", () => {
+    expect(calculateEditorSplitRatio(65, 12)).toBeCloseTo(0.815384, 5);
+    expect(calculateEditorSplitRatio(131, 12)).toBe(0.9);
+    expect(calculateEditorSplitRatio(10, 12)).toBe(0.1);
+  });
+
+  test("creates a focused bottom split using the target pane height", async () => {
+    const requests = await startServer((request) => {
+      if (request.method === "pane.layout") {
+        return {
+          result: {
+            type: "pane_layout",
+            layout: {
+              panes: [{ pane_id: "w1:p1", rect: { height: 65 } }],
+            },
+          },
+        };
+      }
+      return {
+        result: {
+          type: "pane_info",
+          pane: { pane_id: "w1:p2" },
+        },
+      };
+    });
+
+    expect(
+      await splitEditorPane("w1:p1", 12, "/repo with spaces", {
+        NODE_NO_WARNINGS: "1",
+      }),
+    ).toBe("w1:p2");
+    expect(requests[0]).toMatchObject({
+      method: "pane.layout",
+      params: { pane_id: "w1:p1" },
+    });
+    expect(requests[1]).toMatchObject({
+      method: "pane.split",
+      params: {
+        target_pane_id: "w1:p1",
+        direction: "down",
+        ratio: 1 - 12 / 65,
+        focus: true,
+        cwd: "/repo with spaces",
+        env: { NODE_NO_WARNINGS: "1" },
+      },
+    });
+  });
+
+  test("runs an argv command safely and closes panes through the socket API", async () => {
+    const requests = await startServer(() => ({ result: { type: "ok" } }));
+
+    await runCommandInPane("w1:p2", [
+      "node",
+      "/repo with spaces/dist/index.js",
+      "--env",
+      "VALUE=it's safe",
+    ]);
+    await closePane("w1:p2");
+
+    expect(requests[0]).toMatchObject({
+      method: "pane.send_input",
+      params: {
+        pane_id: "w1:p2",
+        text: "exec 'node' '/repo with spaces/dist/index.js' '--env' 'VALUE=it'\\''s safe'",
+        keys: ["Enter"],
+      },
+    });
+    expect(requests[1]).toMatchObject({
+      method: "pane.close",
+      params: { pane_id: "w1:p2" },
+    });
+  });
+});
+
+describe("Herdr editor state", () => {
+  test("registers an editor pane with unique target panes", async () => {
+    await markAsEditorPane("w1:p3", ["w1:p1", "w1:p2", "w1:p1"]);
+
+    expect(isEditorPaneFromConf("w1:p3")).toBe(true);
+    expect(await getTargetPaneIds("w1:p3")).toEqual(["w1:p1", "w1:p2"]);
+    expect(await getEditorPaneId("w1:p1")).toBe("w1:p3");
+    expect(await getEditorPaneId("w1:p2")).toBe("w1:p3");
+  });
+
+  test("clears editor state while preserving quote text", async () => {
+    await markAsEditorPane("w1:p3", ["w1:p1"]);
+    await appendToQuoteText("w1:p1", "> quote\n\n");
+
+    await clearEditorPaneId("w1:p1");
+
+    expect(isEditorPaneFromConf("w1:p3")).toBe(false);
+    expect(await getEditorPaneId("w1:p1")).toBe("");
+    expect(await getQuoteText("w1:p1")).toBe("> quote\n\n");
+  });
+
+  test("does not clear a newer editor registration when an older editor exits", async () => {
+    await markAsEditorPane("w1:p2", ["w1:p1"]);
+    await markAsEditorPane("w1:p3", ["w1:p1"]);
+
+    await clearEditorPaneId("w1:p1", "w1:p2");
+
+    expect(isEditorPaneFromConf("w1:p2")).toBe(false);
+    expect(isEditorPaneFromConf("w1:p3")).toBe(true);
+    expect(await getEditorPaneId("w1:p1")).toBe("w1:p3");
+  });
+
+  test("appends and clears quote text while preserving editor state", async () => {
+    await markAsEditorPane("w1:p3", ["w1:p1"]);
+
+    await appendToQuoteText("w1:p1", "> first\n\n");
+    await appendToQuoteText("w1:p1", "> second\n\n");
+
+    expect(await getQuoteText("w1:p1")).toBe("> first\n\n\n\n> second\n\n");
+
+    await clearQuoteText("w1:p1");
+
+    expect(await getQuoteText("w1:p1")).toBe("");
+    expect(await getEditorPaneId("w1:p1")).toBe("w1:p3");
+  });
+
+  test("isolates editor state between Herdr sessions", async () => {
+    process.env.HERDR_SOCKET_PATH = "/tmp/herdr-session-a.sock";
+    await markAsEditorPane("w1:p3", ["w1:p1"]);
+
+    process.env.HERDR_SOCKET_PATH = "/tmp/herdr-session-b.sock";
+
+    expect(isEditorPaneFromConf("w1:p3")).toBe(false);
+    expect(await getEditorPaneId("w1:p1")).toBe("");
+  });
+
+  test("resumes a registered editor pane from its target pane", async () => {
+    process.env.HERDR_PANE_ID = "w1:p1";
+    const requests = await startServer((request) => {
+      if (request.method === "pane.get") {
+        return { result: { type: "pane_info", pane: { pane_id: "w1:p2" } } };
+      }
+      return { result: { type: "ok" } };
+    });
+    await markAsEditorPane("w1:p2", ["w1:p1"]);
+
+    expect(await resumeEditorPane("w1:p1")).toBe(true);
+    expect(requests.map((request) => request.method)).toEqual(["pane.get", "pane.focus"]);
+    expect(requests[1]?.params).toEqual({ pane_id: "w1:p2" });
+  });
+
+  test("returns false when no editor pane is registered", async () => {
+    process.env.HERDR_PANE_ID = "w1:p1";
+
+    expect(await resumeEditorPane("w1:p1")).toBe(false);
+  });
+});

--- a/test/utils/mux.test.ts
+++ b/test/utils/mux.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { isHerdrEnvironment, resolveMux } from "../../src/utils/mux";
+
+const herdrEnv: NodeJS.ProcessEnv = {
+  HERDR_SOCKET_PATH: "/tmp/herdr.sock",
+  HERDR_PANE_ID: "w1:p1",
+};
+
+describe("isHerdrEnvironment", () => {
+  test("detects a Herdr pane", () => {
+    expect(isHerdrEnvironment(herdrEnv)).toBe(true);
+  });
+
+  test("detects a detached Herdr command with an active pane", () => {
+    expect(
+      isHerdrEnvironment({
+        HERDR_SOCKET_PATH: "/tmp/herdr.sock",
+        HERDR_ACTIVE_PANE_ID: "w1:p1",
+      }),
+    ).toBe(true);
+  });
+
+  test("requires both the socket path and a pane ID", () => {
+    expect(isHerdrEnvironment({ HERDR_SOCKET_PATH: "/tmp/herdr.sock" })).toBe(false);
+    expect(isHerdrEnvironment({ HERDR_PANE_ID: "w1:p1" })).toBe(false);
+  });
+});
+
+describe("resolveMux", () => {
+  test("prefers an explicit mux over the environment", () => {
+    expect(resolveMux("tmux", { ...herdrEnv, EDITPROMPT_MUX: "wezterm" })).toBe("tmux");
+  });
+
+  test("prefers EDITPROMPT_MUX over Herdr detection", () => {
+    expect(resolveMux(undefined, { ...herdrEnv, EDITPROMPT_MUX: "wezterm" })).toBe("wezterm");
+  });
+
+  test("detects Herdr when no mux is explicitly configured", () => {
+    expect(resolveMux(undefined, herdrEnv)).toBe("herdr");
+  });
+
+  test("defaults to tmux outside Herdr", () => {
+    expect(resolveMux(undefined, {})).toBe("tmux");
+  });
+
+  test("rejects an invalid explicit mux", () => {
+    expect(() => resolveMux("invalid", herdrEnv)).toThrow("Invalid multiplexer type");
+  });
+
+  test("rejects an invalid EDITPROMPT_MUX", () => {
+    expect(() => resolveMux(undefined, { EDITPROMPT_MUX: "invalid" })).toThrow(
+      "Invalid multiplexer type",
+    );
+  });
+});

--- a/test/utils/sendConfig.test.ts
+++ b/test/utils/sendConfig.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { readSendConfig } from "../../src/utils/sendConfig";
 
 describe("readSendConfig", () => {
@@ -9,6 +9,10 @@ describe("readSendConfig", () => {
     originalEnv = { ...process.env };
   });
 
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
   test("reads all environment variables when set", () => {
     process.env.EDITPROMPT_MUX = "tmux";
     process.env.EDITPROMPT_ALWAYS_COPY = "1";
@@ -17,9 +21,6 @@ describe("readSendConfig", () => {
 
     expect(config.mux).toBe("tmux");
     expect(config.alwaysCopy).toBe(true);
-
-    // Restore environment variables
-    process.env = originalEnv;
   });
 
   test("throws error when EDITPROMPT_MUX has invalid value", () => {
@@ -27,21 +28,36 @@ describe("readSendConfig", () => {
     process.env.EDITPROMPT_ALWAYS_COPY = "1";
 
     expect(() => readSendConfig()).toThrow();
+  });
 
-    // Restore environment variables
-    process.env = originalEnv;
+  test("accepts herdr as a multiplexer", () => {
+    process.env.EDITPROMPT_MUX = "herdr";
+
+    const config = readSendConfig();
+
+    expect(config.mux).toBe("herdr");
+  });
+
+  test("detects herdr when EDITPROMPT_MUX is not set", () => {
+    delete process.env.EDITPROMPT_MUX;
+    process.env.HERDR_SOCKET_PATH = "/tmp/herdr.sock";
+    process.env.HERDR_PANE_ID = "w1:p1";
+
+    const config = readSendConfig();
+
+    expect(config.mux).toBe("herdr");
   });
 
   test("defaults to tmux when EDITPROMPT_MUX is not set", () => {
-    process.env.EDITPROMPT_MUX = undefined;
+    delete process.env.EDITPROMPT_MUX;
+    delete process.env.HERDR_SOCKET_PATH;
+    delete process.env.HERDR_PANE_ID;
+    delete process.env.HERDR_ACTIVE_PANE_ID;
     process.env.EDITPROMPT_ALWAYS_COPY = "0";
 
     const config = readSendConfig();
 
     expect(config.mux).toBe("tmux");
-
-    // Restore environment variables
-    process.env = originalEnv;
   });
 
   test("sets alwaysCopy to true when EDITPROMPT_ALWAYS_COPY is 1", () => {
@@ -51,9 +67,6 @@ describe("readSendConfig", () => {
     const config = readSendConfig();
 
     expect(config.alwaysCopy).toBe(true);
-
-    // Restore environment variables
-    process.env = originalEnv;
   });
 
   test("defaults sendKeyDelay to 1000 when EDITPROMPT_SEND_KEY_DELAY is not set", () => {
@@ -63,8 +76,6 @@ describe("readSendConfig", () => {
     const config = readSendConfig();
 
     expect(config.sendKeyDelay).toBe(1000);
-
-    process.env = originalEnv;
   });
 
   test("reads sendKeyDelay from EDITPROMPT_SEND_KEY_DELAY", () => {
@@ -74,8 +85,6 @@ describe("readSendConfig", () => {
     const config = readSendConfig();
 
     expect(config.sendKeyDelay).toBe(2000);
-
-    process.env = originalEnv;
   });
 
   test("defaults sendKeyDelay to 1000 when EDITPROMPT_SEND_KEY_DELAY is invalid", () => {
@@ -85,7 +94,5 @@ describe("readSendConfig", () => {
     const config = readSendConfig();
 
     expect(config.sendKeyDelay).toBe(1000);
-
-    process.env = originalEnv;
   });
 });


### PR DESCRIPTION
## Summary

- Add Herdr as a third multiplexer backend alongside tmux and WezTerm, using its newline-delimited JSON socket API.
- Add a `toggle` subcommand that focuses an existing editor pane, or creates a bottom split and runs `open` inside it.
- Unify mux resolution so Herdr is auto-detected from the pane environment.

## Details

- modules/herdr: socket client with timeout and error handling, pane operations (`pane.get` / `pane.focus` / `pane.split` / `pane.close` / `pane.send_text` / `pane.send_keys` / `pane.send_input`), and Conf state namespaced by a hash of `HERDR_SOCKET_PATH` so named sessions stay isolated.
- Content is split into chunks below Herdr's 1MB request limit before sending.
- Editor-side modes (`input` / `press` / `collect` / `dump` / `stash` / `register` / `resume`) route through the Herdr backend; stash keys are session-namespaced as well.
- toggle: sizes the editor split from `--pane-rows` (clamped to Herdr's 10–90% split ratio limits) and closes the created pane when the editor launch fails.

## Behavior change

- Mux resolution is now unified in `resolveMux()`. Previously only editor-side commands read `EDITPROMPT_MUX`; now `open` / `resume` / `collect` also resolve the mux as: explicit `--mux` > `EDITPROMPT_MUX` > Herdr auto-detection (`HERDR_SOCKET_PATH` + pane ID) > `tmux`. Existing tmux/WezTerm setups are unaffected unless `EDITPROMPT_MUX` is set to a conflicting value.

## Testing

- bun test (139 tests; the Herdr module tests exercise a real Unix socket server)
